### PR TITLE
package.json improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,16 +3,13 @@
   "version": "1.0.0",
   "description": "Password criteria authoritor",
   "main": "Criteria/Criteria.js",
-  "peerDependency": {
-    "jquery": "^3.4.1"
+  "scripts": {
+    "build": "babel src --presets babel-preset-es2015 --out-dir Criteria",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cfkarakulak/CriteriaJS.git"
-  },
-  "scripts": {
-    "build": "babel src --presets babel-preset-es2015 --out-dir Criteria",
-    "prepublish": "npm run build"
   },
   "keywords": [
     "password",
@@ -25,6 +22,9 @@
     "url": "https://github.com/cfkarakulak/CriteriaJS/issues"
   },
   "homepage": "https://github.com/cfkarakulak/CriteriaJS#readme",
+  "peerDependencies": {
+    "jquery": "^3.4.1"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.24.1"


### PR DESCRIPTION
- Use "prepare" script over "prepublish" since the latter is deprecated.
 "prepare" serves the same purpose.

- Fix singular "peerDependency", it needs to be plural.
 If jQuery is not present, it will now  properly warn users
 after "npm install" is run.

- Better organize the order of .json entries to not break user habits.